### PR TITLE
Fix handling of ImGuiInputTextFlags.EnterReturnsTrue

### DIFF
--- a/Hexa.NET.ImGui/Manual/Functions/Functions.000.cs
+++ b/Hexa.NET.ImGui/Manual/Functions/Functions.000.cs
@@ -653,7 +653,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextNative(label, pStr0, bufSize, flags, callback, userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -687,7 +687,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextNative(label, pStr0, bufSize, flags, callback, (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -721,7 +721,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextNative(label, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -823,7 +823,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextNative(label, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -1182,7 +1182,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextNative(pStr0, pStr1, bufSize, flags, callback, userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -1237,7 +1237,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextNative(pStr0, pStr1, bufSize, flags, callback, (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -1292,7 +1292,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextNative(pStr0, pStr1, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -1457,7 +1457,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextNative(pStr0, pStr1, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -1607,7 +1607,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextNative((byte*)plabel, pStr0, bufSize, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -1644,7 +1644,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextNative((byte*)plabel, pStr0, bufSize, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -1681,7 +1681,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextNative((byte*)plabel, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -1792,7 +1792,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextNative((byte*)plabel, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -1903,7 +1903,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextNative((byte*)plabel, pStr0, bufSize, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -1940,7 +1940,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextNative((byte*)plabel, pStr0, bufSize, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -1977,7 +1977,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextNative((byte*)plabel, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -2088,7 +2088,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextNative((byte*)plabel, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3061,7 +3061,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextNative(label, pStr0, bufSize, flags, callback, userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -3095,7 +3095,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextNative(label, pStr0, bufSize, flags, callback, (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -3129,7 +3129,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextNative(label, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -3231,7 +3231,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextNative(label, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -3590,7 +3590,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextNative(pStr0, pStr1, bufSize, flags, callback, userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -3645,7 +3645,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextNative(pStr0, pStr1, bufSize, flags, callback, (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -3865,7 +3865,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextNative(pStr0, pStr1, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-			if (ret != 0)
+			if (ret != 0 || flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit())
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -4015,7 +4015,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextNative((byte*)plabel, pStr0, bufSize, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -4052,7 +4052,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextNative((byte*)plabel, pStr0, bufSize, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -4089,7 +4089,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextNative((byte*)plabel, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit())
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -4200,7 +4200,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextNative((byte*)plabel, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit())
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -4311,7 +4311,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextNative((byte*)plabel, pStr0, bufSize, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -4348,7 +4348,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextNative((byte*)plabel, pStr0, bufSize, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -4385,7 +4385,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextNative((byte*)plabel, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -4496,7 +4496,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextNative((byte*)plabel, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}

--- a/Hexa.NET.ImGui/Manual/Functions/Functions.001.cs
+++ b/Hexa.NET.ImGui/Manual/Functions/Functions.001.cs
@@ -1085,7 +1085,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextMultilineNative(label, pStr0, bufSize, size, flags, callback, userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -1119,7 +1119,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextMultilineNative(label, pStr0, bufSize, size, flags, callback, (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -1153,7 +1153,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextMultilineNative(label, pStr0, bufSize, size, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -1255,7 +1255,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextMultilineNative(label, pStr0, bufSize, (Vector2)(new Vector2(0,0)), flags, (ImGuiInputTextCallback)(default), (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -1357,7 +1357,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextMultilineNative(label, pStr0, bufSize, (Vector2)(new Vector2(0,0)), flags, callback, (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -1391,7 +1391,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextMultilineNative(label, pStr0, bufSize, size, flags, (ImGuiInputTextCallback)(default), userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -1493,7 +1493,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextMultilineNative(label, pStr0, bufSize, (Vector2)(new Vector2(0,0)), flags, (ImGuiInputTextCallback)(default), userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -1595,7 +1595,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextMultilineNative(label, pStr0, bufSize, (Vector2)(new Vector2(0,0)), flags, callback, userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -2126,7 +2126,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextMultilineNative(pStr0, pStr1, bufSize, size, flags, callback, userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -2181,7 +2181,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextMultilineNative(pStr0, pStr1, bufSize, size, flags, callback, (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -2236,7 +2236,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextMultilineNative(pStr0, pStr1, bufSize, size, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -2401,7 +2401,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextMultilineNative(pStr0, pStr1, bufSize, (Vector2)(new Vector2(0,0)), flags, (ImGuiInputTextCallback)(default), (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -2566,7 +2566,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextMultilineNative(pStr0, pStr1, bufSize, (Vector2)(new Vector2(0,0)), flags, callback, (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -2621,7 +2621,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextMultilineNative(pStr0, pStr1, bufSize, size, flags, (ImGuiInputTextCallback)(default), userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -2786,7 +2786,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextMultilineNative(pStr0, pStr1, bufSize, (Vector2)(new Vector2(0,0)), flags, (ImGuiInputTextCallback)(default), userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -2951,7 +2951,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextMultilineNative(pStr0, pStr1, bufSize, (Vector2)(new Vector2(0,0)), flags, callback, userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -2991,7 +2991,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, size, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3028,7 +3028,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, size, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3065,7 +3065,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, size, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3176,7 +3176,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, (Vector2)(new Vector2(0,0)), flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3287,7 +3287,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, (Vector2)(new Vector2(0,0)), flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3324,7 +3324,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, size, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3435,7 +3435,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, (Vector2)(new Vector2(0,0)), flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3546,7 +3546,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, (Vector2)(new Vector2(0,0)), flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3583,7 +3583,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, size, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3620,7 +3620,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, size, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3657,7 +3657,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, size, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3768,7 +3768,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, (Vector2)(new Vector2(0,0)), flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3879,7 +3879,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, (Vector2)(new Vector2(0,0)), flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3916,7 +3916,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, size, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -4027,7 +4027,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, (Vector2)(new Vector2(0,0)), flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -4138,7 +4138,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, (Vector2)(new Vector2(0,0)), flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}

--- a/Hexa.NET.ImGui/Manual/Functions/Functions.002.cs
+++ b/Hexa.NET.ImGui/Manual/Functions/Functions.002.cs
@@ -893,7 +893,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextMultilineNative(label, pStr0, bufSize, size, flags, callback, userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -927,7 +927,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextMultilineNative(label, pStr0, bufSize, size, flags, callback, (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -961,7 +961,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextMultilineNative(label, pStr0, bufSize, size, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -1063,7 +1063,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextMultilineNative(label, pStr0, bufSize, (Vector2)(new Vector2(0,0)), flags, (ImGuiInputTextCallback)(default), (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -1165,7 +1165,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextMultilineNative(label, pStr0, bufSize, (Vector2)(new Vector2(0,0)), flags, callback, (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -1199,7 +1199,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextMultilineNative(label, pStr0, bufSize, size, flags, (ImGuiInputTextCallback)(default), userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -1301,7 +1301,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextMultilineNative(label, pStr0, bufSize, (Vector2)(new Vector2(0,0)), flags, (ImGuiInputTextCallback)(default), userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -1403,7 +1403,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextMultilineNative(label, pStr0, bufSize, (Vector2)(new Vector2(0,0)), flags, callback, userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -1934,7 +1934,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextMultilineNative(pStr0, pStr1, bufSize, size, flags, callback, userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -1989,7 +1989,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextMultilineNative(pStr0, pStr1, bufSize, size, flags, callback, (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -2044,7 +2044,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextMultilineNative(pStr0, pStr1, bufSize, size, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -2209,7 +2209,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextMultilineNative(pStr0, pStr1, bufSize, (Vector2)(new Vector2(0,0)), flags, (ImGuiInputTextCallback)(default), (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -2374,7 +2374,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextMultilineNative(pStr0, pStr1, bufSize, (Vector2)(new Vector2(0,0)), flags, callback, (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -2429,7 +2429,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextMultilineNative(pStr0, pStr1, bufSize, size, flags, (ImGuiInputTextCallback)(default), userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -2594,7 +2594,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextMultilineNative(pStr0, pStr1, bufSize, (Vector2)(new Vector2(0,0)), flags, (ImGuiInputTextCallback)(default), userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -2759,7 +2759,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextMultilineNative(pStr0, pStr1, bufSize, (Vector2)(new Vector2(0,0)), flags, callback, userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -2799,7 +2799,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, size, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -2836,7 +2836,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, size, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -2873,7 +2873,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, size, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -2984,7 +2984,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, (Vector2)(new Vector2(0,0)), flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3095,7 +3095,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, (Vector2)(new Vector2(0,0)), flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3132,7 +3132,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, size, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3243,7 +3243,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, (Vector2)(new Vector2(0,0)), flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3354,7 +3354,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, (Vector2)(new Vector2(0,0)), flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3576,7 +3576,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, (Vector2)(new Vector2(0,0)), flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3687,7 +3687,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, (Vector2)(new Vector2(0,0)), flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3724,7 +3724,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, size, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3835,7 +3835,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, (Vector2)(new Vector2(0,0)), flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3946,7 +3946,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextMultilineNative((byte*)plabel, pStr0, bufSize, (Vector2)(new Vector2(0,0)), flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}

--- a/Hexa.NET.ImGui/Manual/Functions/Functions.003.cs
+++ b/Hexa.NET.ImGui/Manual/Functions/Functions.003.cs
@@ -2489,7 +2489,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextWithHintNative(label, hint, pStr0, bufSize, flags, callback, userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -2523,7 +2523,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextWithHintNative(label, hint, pStr0, bufSize, flags, callback, (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -2557,7 +2557,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextWithHintNative(label, hint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -2659,7 +2659,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextWithHintNative(label, hint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -3018,7 +3018,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextWithHintNative(pStr0, hint, pStr1, bufSize, flags, callback, userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -3073,7 +3073,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextWithHintNative(pStr0, hint, pStr1, bufSize, flags, callback, (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -3128,7 +3128,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextWithHintNative(pStr0, hint, pStr1, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -3293,7 +3293,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextWithHintNative(pStr0, hint, pStr1, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -3443,7 +3443,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, hint, pStr0, bufSize, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3480,7 +3480,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, hint, pStr0, bufSize, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3517,7 +3517,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, hint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3628,7 +3628,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, hint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3739,7 +3739,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, hint, pStr0, bufSize, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3776,7 +3776,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, hint, pStr0, bufSize, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3813,7 +3813,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, hint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3924,7 +3924,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, hint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -4554,7 +4554,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextWithHintNative(label, pStr0, pStr1, bufSize, flags, callback, userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -4609,7 +4609,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextWithHintNative(label, pStr0, pStr1, bufSize, flags, callback, (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -4664,7 +4664,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextWithHintNative(label, pStr0, pStr1, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -4829,7 +4829,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextWithHintNative(label, pStr0, pStr1, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -4979,7 +4979,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative(label, (byte*)phint, pStr0, bufSize, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -5016,7 +5016,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative(label, (byte*)phint, pStr0, bufSize, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}

--- a/Hexa.NET.ImGui/Manual/Functions/Functions.004.cs
+++ b/Hexa.NET.ImGui/Manual/Functions/Functions.004.cs
@@ -43,7 +43,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative(label, (byte*)phint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -154,7 +154,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative(label, (byte*)phint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -265,7 +265,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative(label, (byte*)phint, pStr0, bufSize, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -302,7 +302,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative(label, (byte*)phint, pStr0, bufSize, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -339,7 +339,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative(label, (byte*)phint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -450,7 +450,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative(label, (byte*)phint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -1145,7 +1145,7 @@ namespace Hexa.NET.ImGui
 				pStr2[pStrOffset2] = 0;
 			}
 			byte ret = InputTextWithHintNative(pStr0, pStr1, pStr2, bufSize, flags, callback, userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr2);
 			}
@@ -1221,7 +1221,7 @@ namespace Hexa.NET.ImGui
 				pStr2[pStrOffset2] = 0;
 			}
 			byte ret = InputTextWithHintNative(pStr0, pStr1, pStr2, bufSize, flags, callback, (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr2);
 			}
@@ -1297,7 +1297,7 @@ namespace Hexa.NET.ImGui
 				pStr2[pStrOffset2] = 0;
 			}
 			byte ret = InputTextWithHintNative(pStr0, pStr1, pStr2, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr2);
 			}
@@ -1525,7 +1525,7 @@ namespace Hexa.NET.ImGui
 				pStr2[pStrOffset2] = 0;
 			}
 			byte ret = InputTextWithHintNative(pStr0, pStr1, pStr2, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr2);
 			}
@@ -1723,7 +1723,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, callback, userData);
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -1763,7 +1763,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, callback, (void*)(default));
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -1803,7 +1803,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -1923,7 +1923,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -2187,7 +2187,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, callback, userData);
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -2227,7 +2227,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, callback, (void*)(default));
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -2267,7 +2267,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -2387,7 +2387,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -2810,7 +2810,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, pStr0, pStr1, bufSize, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -2926,7 +2926,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, pStr0, pStr1, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -3100,7 +3100,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, pStr0, pStr1, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -3403,7 +3403,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, callback, userData);
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -3443,7 +3443,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, callback, (void*)(default));
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -3483,7 +3483,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -3542,8 +3542,7 @@ namespace Hexa.NET.ImGui
 		public static bool InputTextWithHint(ReadOnlySpan<byte> label, ref byte hint, ref string buf, ulong bufSize, ImGuiInputTextCallback callback)
 		{
 			fixed (byte* plabel = label)
-			{
-				fixed (byte* phint = &hint)
+			{ fixed (byte* phint = &hint)
 				{
 					byte* pStr0 = null;
 					int pStrSize0 = 0;
@@ -3603,7 +3602,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -3723,7 +3722,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, callback, userData);
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -3763,7 +3762,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, callback, (void*)(default));
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -3803,7 +3802,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -3923,7 +3922,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -4346,7 +4345,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, pStr0, pStr1, bufSize, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -4404,7 +4403,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, pStr0, pStr1, bufSize, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -4462,7 +4461,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, pStr0, pStr1, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -4636,7 +4635,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, pStr0, pStr1, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}

--- a/Hexa.NET.ImGui/Manual/Functions/Functions.005.cs
+++ b/Hexa.NET.ImGui/Manual/Functions/Functions.005.cs
@@ -96,7 +96,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative(pStr0, (byte*)phint, pStr1, bufSize, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && ImGui.IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -154,7 +154,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative(pStr0, (byte*)phint, pStr1, bufSize, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && ImGui.IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -212,7 +212,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative(pStr0, (byte*)phint, pStr1, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && ImGui.IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -386,7 +386,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative(pStr0, (byte*)phint, pStr1, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && ImGui.IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -848,7 +848,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative(pStr0, (byte*)phint, pStr1, bufSize, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && ImGui.IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -906,7 +906,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative(pStr0, (byte*)phint, pStr1, bufSize, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && ImGui.IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -964,7 +964,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative(pStr0, (byte*)phint, pStr1, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && ImGui.IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -1138,7 +1138,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative(pStr0, (byte*)phint, pStr1, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && ImGui.IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -4701,7 +4701,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextWithHintNative(label, hint, pStr0, bufSize, flags, callback, userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -4735,7 +4735,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextWithHintNative(label, hint, pStr0, bufSize, flags, callback, (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -4769,7 +4769,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextWithHintNative(label, hint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -4871,7 +4871,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextWithHintNative(label, hint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}

--- a/Hexa.NET.ImGui/Manual/Functions/Functions.006.cs
+++ b/Hexa.NET.ImGui/Manual/Functions/Functions.006.cs
@@ -223,7 +223,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextWithHintNative(pStr0, hint, pStr1, bufSize, flags, callback, userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -278,7 +278,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextWithHintNative(pStr0, hint, pStr1, bufSize, flags, callback, (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -333,7 +333,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextWithHintNative(pStr0, hint, pStr1, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -498,7 +498,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextWithHintNative(pStr0, hint, pStr1, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -648,7 +648,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, hint, pStr0, bufSize, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -685,7 +685,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, hint, pStr0, bufSize, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -722,7 +722,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, hint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -833,7 +833,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, hint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -944,7 +944,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, hint, pStr0, bufSize, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -981,7 +981,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, hint, pStr0, bufSize, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -1018,7 +1018,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, hint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -1129,7 +1129,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, hint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -1759,7 +1759,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextWithHintNative(label, pStr0, pStr1, bufSize, flags, callback, userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -1814,7 +1814,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextWithHintNative(label, pStr0, pStr1, bufSize, flags, callback, (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -1869,7 +1869,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextWithHintNative(label, pStr0, pStr1, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -2034,7 +2034,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextWithHintNative(label, pStr0, pStr1, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -2184,7 +2184,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative(label, (byte*)phint, pStr0, bufSize, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -2221,7 +2221,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative(label, (byte*)phint, pStr0, bufSize, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -2258,7 +2258,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative(label, (byte*)phint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -2369,7 +2369,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative(label, (byte*)phint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -2480,7 +2480,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative(label, (byte*)phint, pStr0, bufSize, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -2517,7 +2517,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative(label, (byte*)phint, pStr0, bufSize, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -2554,7 +2554,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative(label, (byte*)phint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -2665,7 +2665,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextWithHintNative(label, (byte*)phint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -3360,7 +3360,7 @@ namespace Hexa.NET.ImGui
 				pStr2[pStrOffset2] = 0;
 			}
 			byte ret = InputTextWithHintNative(pStr0, pStr1, pStr2, bufSize, flags, callback, userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr2);
 			}
@@ -3436,7 +3436,7 @@ namespace Hexa.NET.ImGui
 				pStr2[pStrOffset2] = 0;
 			}
 			byte ret = InputTextWithHintNative(pStr0, pStr1, pStr2, bufSize, flags, callback, (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr2);
 			}
@@ -3512,7 +3512,7 @@ namespace Hexa.NET.ImGui
 				pStr2[pStrOffset2] = 0;
 			}
 			byte ret = InputTextWithHintNative(pStr0, pStr1, pStr2, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr2);
 			}
@@ -3740,7 +3740,7 @@ namespace Hexa.NET.ImGui
 				pStr2[pStrOffset2] = 0;
 			}
 			byte ret = InputTextWithHintNative(pStr0, pStr1, pStr2, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr2);
 			}
@@ -3938,7 +3938,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, callback, userData);
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -3978,7 +3978,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, callback, (void*)(default));
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -4018,7 +4018,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -4138,7 +4138,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -4402,7 +4402,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, callback, userData);
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -4442,7 +4442,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, callback, (void*)(default));
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -4482,7 +4482,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -4602,7 +4602,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -5025,7 +5025,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, pStr0, pStr1, bufSize, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}

--- a/Hexa.NET.ImGui/Manual/Functions/Functions.007.cs
+++ b/Hexa.NET.ImGui/Manual/Functions/Functions.007.cs
@@ -60,7 +60,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, pStr0, pStr1, bufSize, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -118,7 +118,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, pStr0, pStr1, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -292,7 +292,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, pStr0, pStr1, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -595,7 +595,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, callback, userData);
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -635,7 +635,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, callback, (void*)(default));
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -675,7 +675,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -795,7 +795,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -915,7 +915,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, callback, userData);
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -955,7 +955,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, callback, (void*)(default));
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -995,7 +995,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -1115,7 +1115,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextWithHintNative((byte*)plabel, (byte*)phint, pStr0, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -1538,7 +1538,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, pStr0, pStr1, bufSize, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -1596,7 +1596,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, pStr0, pStr1, bufSize, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -1654,7 +1654,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, pStr0, pStr1, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -1828,7 +1828,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative((byte*)plabel, pStr0, pStr1, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -2290,7 +2290,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative(pStr0, (byte*)phint, pStr1, bufSize, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -2348,7 +2348,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative(pStr0, (byte*)phint, pStr1, bufSize, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -2406,7 +2406,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative(pStr0, (byte*)phint, pStr1, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -2580,7 +2580,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative(pStr0, (byte*)phint, pStr1, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -3042,7 +3042,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative(pStr0, (byte*)phint, pStr1, bufSize, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -3100,7 +3100,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative(pStr0, (byte*)phint, pStr1, bufSize, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -3158,7 +3158,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative(pStr0, (byte*)phint, pStr1, bufSize, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -3332,7 +3332,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextWithHintNative(pStr0, (byte*)phint, pStr1, bufSize, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}

--- a/Hexa.NET.ImGui/Manual/Functions/Functions.009.cs
+++ b/Hexa.NET.ImGui/Manual/Functions/Functions.009.cs
@@ -737,7 +737,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextExNative(label, hint, pStr0, bufSize, sizeArg, flags, callback, userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -771,7 +771,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextExNative(label, hint, pStr0, bufSize, sizeArg, flags, callback, (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -805,7 +805,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextExNative(label, hint, pStr0, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -839,7 +839,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = InputTextExNative(label, hint, pStr0, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -1010,7 +1010,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextExNative(pStr0, hint, pStr1, bufSize, sizeArg, flags, callback, userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -1065,7 +1065,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextExNative(pStr0, hint, pStr1, bufSize, sizeArg, flags, callback, (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -1120,7 +1120,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextExNative(pStr0, hint, pStr1, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -1175,7 +1175,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextExNative(pStr0, hint, pStr1, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -1215,7 +1215,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextExNative((byte*)plabel, hint, pStr0, bufSize, sizeArg, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -1252,7 +1252,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextExNative((byte*)plabel, hint, pStr0, bufSize, sizeArg, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -1289,7 +1289,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextExNative((byte*)plabel, hint, pStr0, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -1326,7 +1326,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextExNative((byte*)plabel, hint, pStr0, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -1363,7 +1363,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextExNative((byte*)plabel, hint, pStr0, bufSize, sizeArg, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -1400,7 +1400,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextExNative((byte*)plabel, hint, pStr0, bufSize, sizeArg, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -1437,7 +1437,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextExNative((byte*)plabel, hint, pStr0, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -1474,7 +1474,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextExNative((byte*)plabel, hint, pStr0, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -1778,7 +1778,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextExNative(label, pStr0, pStr1, bufSize, sizeArg, flags, callback, userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -1833,7 +1833,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextExNative(label, pStr0, pStr1, bufSize, sizeArg, flags, callback, (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -1888,7 +1888,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextExNative(label, pStr0, pStr1, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -1943,7 +1943,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = InputTextExNative(label, pStr0, pStr1, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -1983,7 +1983,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextExNative(label, (byte*)phint, pStr0, bufSize, sizeArg, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -2020,7 +2020,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextExNative(label, (byte*)phint, pStr0, bufSize, sizeArg, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -2057,7 +2057,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextExNative(label, (byte*)phint, pStr0, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -2094,7 +2094,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextExNative(label, (byte*)phint, pStr0, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -2131,7 +2131,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextExNative(label, (byte*)phint, pStr0, bufSize, sizeArg, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -2168,7 +2168,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextExNative(label, (byte*)phint, pStr0, bufSize, sizeArg, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -2205,7 +2205,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextExNative(label, (byte*)phint, pStr0, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -2242,7 +2242,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = InputTextExNative(label, (byte*)phint, pStr0, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -2587,7 +2587,7 @@ namespace Hexa.NET.ImGui
 				pStr2[pStrOffset2] = 0;
 			}
 			byte ret = InputTextExNative(pStr0, pStr1, pStr2, bufSize, sizeArg, flags, callback, userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr2);
 			}
@@ -2663,7 +2663,7 @@ namespace Hexa.NET.ImGui
 				pStr2[pStrOffset2] = 0;
 			}
 			byte ret = InputTextExNative(pStr0, pStr1, pStr2, bufSize, sizeArg, flags, callback, (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr2);
 			}
@@ -2739,7 +2739,7 @@ namespace Hexa.NET.ImGui
 				pStr2[pStrOffset2] = 0;
 			}
 			byte ret = InputTextExNative(pStr0, pStr1, pStr2, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr2);
 			}
@@ -2815,7 +2815,7 @@ namespace Hexa.NET.ImGui
 				pStr2[pStrOffset2] = 0;
 			}
 			byte ret = InputTextExNative(pStr0, pStr1, pStr2, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), userData);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr2);
 			}
@@ -2861,7 +2861,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextExNative((byte*)plabel, (byte*)phint, pStr0, bufSize, sizeArg, flags, callback, userData);
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -2901,7 +2901,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextExNative((byte*)plabel, (byte*)phint, pStr0, bufSize, sizeArg, flags, callback, (void*)(default));
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -2941,7 +2941,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextExNative((byte*)plabel, (byte*)phint, pStr0, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -2981,7 +2981,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextExNative((byte*)plabel, (byte*)phint, pStr0, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), userData);
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -3093,7 +3093,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextExNative((byte*)plabel, (byte*)phint, pStr0, bufSize, sizeArg, flags, callback, userData);
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -3133,7 +3133,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextExNative((byte*)plabel, (byte*)phint, pStr0, bufSize, sizeArg, flags, callback, (void*)(default));
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -3173,7 +3173,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextExNative((byte*)plabel, (byte*)phint, pStr0, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -3213,7 +3213,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextExNative((byte*)plabel, (byte*)phint, pStr0, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), userData);
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -3412,7 +3412,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextExNative((byte*)plabel, pStr0, pStr1, bufSize, sizeArg, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -3470,7 +3470,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextExNative((byte*)plabel, pStr0, pStr1, bufSize, sizeArg, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -3528,7 +3528,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextExNative((byte*)plabel, pStr0, pStr1, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -3586,7 +3586,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextExNative((byte*)plabel, pStr0, pStr1, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -3701,7 +3701,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextExNative((byte*)plabel, (byte*)phint, pStr0, bufSize, sizeArg, flags, callback, userData);
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -3741,7 +3741,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextExNative((byte*)plabel, (byte*)phint, pStr0, bufSize, sizeArg, flags, callback, (void*)(default));
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -3781,7 +3781,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextExNative((byte*)plabel, (byte*)phint, pStr0, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -3821,7 +3821,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextExNative((byte*)plabel, (byte*)phint, pStr0, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), userData);
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -3861,7 +3861,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextExNative((byte*)plabel, (byte*)phint, pStr0, bufSize, sizeArg, flags, callback, userData);
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -3901,7 +3901,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextExNative((byte*)plabel, (byte*)phint, pStr0, bufSize, sizeArg, flags, callback, (void*)(default));
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -3941,7 +3941,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextExNative((byte*)plabel, (byte*)phint, pStr0, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -3981,7 +3981,7 @@ namespace Hexa.NET.ImGui
 						pStr0[pStrOffset0] = 0;
 					}
 					byte ret = InputTextExNative((byte*)plabel, (byte*)phint, pStr0, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), userData);
-					if (ret != 0)
+					if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 					{
 						buf = Utils.DecodeStringUTF8(pStr0);
 					}
@@ -4180,7 +4180,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextExNative((byte*)plabel, pStr0, pStr1, bufSize, sizeArg, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -4238,7 +4238,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextExNative((byte*)plabel, pStr0, pStr1, bufSize, sizeArg, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -4296,7 +4296,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextExNative((byte*)plabel, pStr0, pStr1, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -4354,7 +4354,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextExNative((byte*)plabel, pStr0, pStr1, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -4556,7 +4556,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextExNative(pStr0, (byte*)phint, pStr1, bufSize, sizeArg, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -4614,7 +4614,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextExNative(pStr0, (byte*)phint, pStr1, bufSize, sizeArg, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -4672,7 +4672,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextExNative(pStr0, (byte*)phint, pStr1, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -4730,7 +4730,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextExNative(pStr0, (byte*)phint, pStr1, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -4932,7 +4932,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextExNative(pStr0, (byte*)phint, pStr1, bufSize, sizeArg, flags, callback, userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -4990,7 +4990,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextExNative(pStr0, (byte*)phint, pStr1, bufSize, sizeArg, flags, callback, (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -5048,7 +5048,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextExNative(pStr0, (byte*)phint, pStr1, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), (void*)(default));
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}

--- a/Hexa.NET.ImGui/Manual/Functions/Functions.010.cs
+++ b/Hexa.NET.ImGui/Manual/Functions/Functions.010.cs
@@ -60,7 +60,7 @@ namespace Hexa.NET.ImGui
 					pStr1[pStrOffset1] = 0;
 				}
 				byte ret = InputTextExNative(pStr0, (byte*)phint, pStr1, bufSize, sizeArg, flags, (ImGuiInputTextCallback)(default), userData);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr1);
 				}
@@ -403,7 +403,7 @@ namespace Hexa.NET.ImGui
 				pStr0[pStrOffset0] = 0;
 			}
 			byte ret = TempInputTextNative(bb, id, label, pStr0, bufSize, flags);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr0);
 			}
@@ -484,7 +484,7 @@ namespace Hexa.NET.ImGui
 				pStr1[pStrOffset1] = 0;
 			}
 			byte ret = TempInputTextNative(bb, id, pStr0, pStr1, bufSize, flags);
-			if (ret != 0)
+			if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 			{
 				buf = Utils.DecodeStringUTF8(pStr1);
 			}
@@ -524,7 +524,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = TempInputTextNative(bb, id, (byte*)plabel, pStr0, bufSize, flags);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}
@@ -561,7 +561,7 @@ namespace Hexa.NET.ImGui
 					pStr0[pStrOffset0] = 0;
 				}
 				byte ret = TempInputTextNative(bb, id, (byte*)plabel, pStr0, bufSize, flags);
-				if (ret != 0)
+				if (ret != 0 || (flags.HasFlag(ImGuiInputTextFlags.EnterReturnsTrue) && IsItemDeactivatedAfterEdit()))
 				{
 					buf = Utils.DecodeStringUTF8(pStr0);
 				}


### PR DESCRIPTION
This pull request resolves issue #53.

This pull request updates `InputText` and related methods in `Hexa.NET.ImGui/Manual/Functions` where a `ref string`-typed buffer is used. The logic for determining whether to marshal back to the managed buffer is updated to copy when `ImGui.IsItemDeactivatedAfterEdit()` returns true when the `ImGuiInputTextFlags.EnterReturnsTrue` flag is present. Previously the buffer was only updated when the native call returned true, however the presence of the `EnterReturnsTrue` flag breaks this behavior by inhibiting copies in most cases. When the flag is present, `IsItemDeactivatedAfterEdit()` returns true in exactly the set of cases where the managed buffer should be updated.

The changes introduced have negligible performance impact as demonstrated in [this benchmark](https://github.com/opticfluorine/ImguiBenchmarks).